### PR TITLE
feat(ErrorBoundary): #Y-25 Настроить обработку ошибок внутри «детей» React-компонентов

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -18,6 +18,7 @@
     "@types/react-redux": "^7.1.33",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-error-boundary": "^4.0.12",
     "react-router-dom": "6.20.1"
   },
   "devDependencies": {

--- a/packages/client/src/app.tsx
+++ b/packages/client/src/app.tsx
@@ -1,15 +1,15 @@
+'use client'
 import { ThemeProvider } from '@gravity-ui/uikit'
-import React from 'react'
 import { RouterProvider } from 'react-router-dom'
+import Error from '@components/error'
 import withAuthInfo from 'hoc/withAuthInfo'
 import router from './router'
 
 const App = () => (
-  <React.StrictMode>
-    <ThemeProvider theme="light">
-      <RouterProvider router={router} />
-    </ThemeProvider>
-  </React.StrictMode>
+  <ThemeProvider theme="light">
+    <RouterProvider router={router} />
+    <Error />
+  </ThemeProvider>
 )
 
 export default withAuthInfo(App)

--- a/packages/client/src/assets/styles/common.css
+++ b/packages/client/src/assets/styles/common.css
@@ -5,6 +5,7 @@
   --colors-gray: #c2c9c3;
   --colors-gray-dark: #acb6bc;
   --colors-red: #cb0000;
+  --colors-light-red: #f9c6c6;
   --colors-green-light: #c3cfc8;
   --colors-green-text: #5b7c6c;
   --colors-green: #749080;

--- a/packages/client/src/components/error/error.module.scss
+++ b/packages/client/src/components/error/error.module.scss
@@ -1,0 +1,34 @@
+.errorContainer {
+  position: absolute;
+  inset-block-end: 10px;
+  inset-inline-end: 10px;
+  padding: 10px;
+  border: 1px solid var(--colors-red);
+  border-radius: 10px 10px 0;
+  background: var(--colors-light-red);
+}
+
+.errorInner {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  inline-size: 100%;
+  padding-block: 15px;
+  padding-inline: 15px;
+  box-sizing: border-box;
+}
+
+.errorHeader {
+  padding-block-end: 10px;
+  font-weight: 800;
+  font-size: 16px;
+}
+
+.resetError {
+  position: absolute;
+  inset-block-start: 5px;
+  inset-inline-end: 5px;
+  font-size: 18px;
+  text-align: end;
+  cursor: pointer;
+}

--- a/packages/client/src/components/error/error.tsx
+++ b/packages/client/src/components/error/error.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { selectError, resetError } from 'reducers/error'
 import store from 'store'
@@ -5,27 +6,34 @@ import styles from './error.module.scss'
 
 export const Error = () => {
   const error = useSelector(selectError)
-
-  const timeoutId = setTimeout(() => {
-    store.dispatch(resetError())
-  }, 10000)
+  let timeoutId: ReturnType<typeof setTimeout>
+  useEffect(() => {
+    timeoutId = setTimeout(() => {
+      store.dispatch(resetError())
+    }, 10000)
+    return () => {
+      clearTimeout(timeoutId)
+    }
+  }, [])
 
   return !error.hasError ? (
     <> </>
   ) : (
-    <div className={styles.errorContainer}>
-      <div
-        className={styles.resetError}
-        onClick={() => {
-          clearTimeout(timeoutId)
-          store.dispatch(resetError())
-        }}>
-        &times;
+    error.hasError && (
+      <div className={styles.errorContainer}>
+        <div
+          className={styles.resetError}
+          onClick={() => {
+            clearTimeout(timeoutId)
+            store.dispatch(resetError())
+          }}>
+          &times;
+        </div>
+        <div className={styles.errorInner}>
+          <div className={styles.errorHeader}>Что-то пошло не так...</div>
+          <div className={styles.errorMessage}>{error.message}</div>
+        </div>
       </div>
-      <div className={styles.errorInner}>
-        <div className={styles.errorHeader}>Что-то пошло не так...</div>
-        <div className={styles.errorMessage}>{error.message}</div>
-      </div>
-    </div>
+    )
   )
 }

--- a/packages/client/src/components/error/error.tsx
+++ b/packages/client/src/components/error/error.tsx
@@ -1,0 +1,31 @@
+import { useSelector } from 'react-redux'
+import { selectError, resetError } from 'reducers/error'
+import store from 'store'
+import styles from './error.module.scss'
+
+export const Error = () => {
+  const error = useSelector(selectError)
+
+  const timeoutId = setTimeout(() => {
+    store.dispatch(resetError())
+  }, 10000)
+
+  return !error.hasError ? (
+    <> </>
+  ) : (
+    <div className={styles.errorContainer}>
+      <div
+        className={styles.resetError}
+        onClick={() => {
+          clearTimeout(timeoutId)
+          store.dispatch(resetError())
+        }}>
+        &times;
+      </div>
+      <div className={styles.errorInner}>
+        <div className={styles.errorHeader}>Что-то пошло не так...</div>
+        <div className={styles.errorMessage}>{error.message}</div>
+      </div>
+    </div>
+  )
+}

--- a/packages/client/src/components/error/index.ts
+++ b/packages/client/src/components/error/index.ts
@@ -1,0 +1,3 @@
+import { Error } from './error'
+
+export default Error

--- a/packages/client/src/components/errorB/errorB.module.scss
+++ b/packages/client/src/components/errorB/errorB.module.scss
@@ -1,0 +1,23 @@
+.errorContainer {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  block-size: 100vh;
+}
+
+.errorInner {
+  inline-size: 100%;
+  padding: 15px;
+  box-sizing: border-box;
+  font-size: 24px;
+  line-height: 1.5;
+  text-align: center;
+  background: var(--colors-light-red);
+  border-block-start: 1px solid var(--colors-red);
+  border-block-end: 1px solid var(--colors-red);
+}
+
+.errorHeader {
+  font-weight: 800;
+}

--- a/packages/client/src/components/errorB/errorB.tsx
+++ b/packages/client/src/components/errorB/errorB.tsx
@@ -1,0 +1,19 @@
+import styles from './errorB.module.scss'
+
+interface ErrorBProps {
+  error: Error
+  resetErrorBoundary: () => void
+}
+export const ErrorB = ({ error, resetErrorBoundary }: ErrorBProps) => {
+  setTimeout(resetErrorBoundary, 2000)
+  return !error.message ? (
+    <> </>
+  ) : (
+    <div className={styles.errorContainer}>
+      <div className={styles.errorInner}>
+        <div className={styles.errorHeader}>Что-то пошло не так</div>
+        <div className={styles.errorMessage}>{error.message}</div>
+      </div>
+    </div>
+  )
+}

--- a/packages/client/src/components/errorB/errorB.tsx
+++ b/packages/client/src/components/errorB/errorB.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import styles from './errorB.module.scss'
 
 interface ErrorBProps {
@@ -5,7 +6,16 @@ interface ErrorBProps {
   resetErrorBoundary: () => void
 }
 export const ErrorB = ({ error, resetErrorBoundary }: ErrorBProps) => {
-  setTimeout(resetErrorBoundary, 2000)
+  let timeoutId: ReturnType<typeof setTimeout>
+  useEffect(() => {
+    timeoutId = setTimeout(() => {
+      resetErrorBoundary()
+    }, 10000)
+    return () => {
+      clearTimeout(timeoutId)
+    }
+  }, [])
+
   return !error.message ? (
     <> </>
   ) : (

--- a/packages/client/src/components/errorB/index.ts
+++ b/packages/client/src/components/errorB/index.ts
@@ -1,0 +1,3 @@
+import { ErrorB } from './errorB'
+
+export default ErrorB

--- a/packages/client/src/hoc/withErrorInfo.tsx
+++ b/packages/client/src/hoc/withErrorInfo.tsx
@@ -1,0 +1,13 @@
+import { ErrorBoundary } from 'react-error-boundary'
+import ErrorB from '@components/errorB'
+
+const withErrorInfo = (OriginalComponent: React.ComponentType) => {
+  const ComponentWithError = () => (
+    <ErrorBoundary FallbackComponent={ErrorB}>
+      <OriginalComponent />
+    </ErrorBoundary>
+  )
+
+  return ComponentWithError
+}
+export default withErrorInfo

--- a/packages/client/src/pages/authPage/authPage.tsx
+++ b/packages/client/src/pages/authPage/authPage.tsx
@@ -18,6 +18,7 @@ import SignUp from './components/signUp'
 
 export const AuthPage = () => {
   const [activeTab, setActiveTab] = useState('signin')
+
   /**
    * если пользователь авторизован, то на эту страницу не зайти
    */

--- a/packages/client/src/reducers/error.ts
+++ b/packages/client/src/reducers/error.ts
@@ -19,7 +19,8 @@ const errorSlice = createSlice({
       state.hasError = true
     },
     resetError: (state: ErrorState) => {
-      ;(state.message = ''), (state.hasError = false)
+      state.message = ''
+      state.hasError = false
     },
   },
 })

--- a/packages/client/src/reducers/error.ts
+++ b/packages/client/src/reducers/error.ts
@@ -1,0 +1,31 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import { type RootStateType } from '../store'
+
+interface ErrorState {
+  message: string
+  hasError: boolean
+}
+export const defaultState: ErrorState = {
+  message: '',
+  hasError: false,
+}
+
+const errorSlice = createSlice({
+  name: 'error',
+  initialState: defaultState,
+  reducers: {
+    setError: (state: ErrorState, action: PayloadAction<string>) => {
+      state.message = action.payload
+      state.hasError = true
+    },
+    resetError: (state: ErrorState) => {
+      ;(state.message = ''), (state.hasError = false)
+    },
+  },
+})
+
+export default errorSlice.reducer
+export const { setError, resetError } = errorSlice.actions
+
+/**Selectors */
+export const selectError = (state: RootStateType) => state.error

--- a/packages/client/src/reducers/index.ts
+++ b/packages/client/src/reducers/index.ts
@@ -1,9 +1,11 @@
 import { combineReducers } from '@reduxjs/toolkit'
+import errorSlice from './error'
 import getGameStartFinishDataSlice from './gameStartFinish'
 import userSlice from './user'
 
 const rootReducer = combineReducers({
   user: userSlice,
+  error: errorSlice,
   gameStartFinishData: getGameStartFinishDataSlice,
 })
 

--- a/packages/client/src/router.tsx
+++ b/packages/client/src/router.tsx
@@ -10,49 +10,50 @@ import MainPage from '@pages/mainPage'
 import NewTopicPage from '@pages/newTopicPage'
 import ProfilePage from '@pages/profilePage'
 import TopicPage from '@pages/topicPage'
+import withErrorInfo from 'hoc/withErrorInfo'
 import { selectUserUserInfo } from 'reducers/user'
 
 const router = createBrowserRouter([
   {
     path: '/login',
-    element: <AuthPage />,
+    Component: withErrorInfo(AuthPage),
   },
   {
     element: <PrivateRoute />,
     children: [
       {
         path: '/',
-        element: <MainPage />,
+        Component: withErrorInfo(MainPage),
       },
       {
         path: '/game',
-        element: <GamePage />,
+        Component: withErrorInfo(GamePage),
       },
       {
         path: '/profile',
-        Component: () => {
+        Component: withErrorInfo(() => {
           const userProps = useSelector(selectUserUserInfo)
           return userProps ? <ProfilePage {...userProps} /> : <Navigate to="/login" replace />
-        },
+        }),
       },
       {
         path: '/rating',
-        element: <Leaderboard />,
+        Component: withErrorInfo(Leaderboard),
       },
       {
         path: '/forum',
-        element: <ForumPage />,
+        Component: withErrorInfo(ForumPage),
       },
       {
         path: '/forum/:topicId',
-        Component: () => {
+        Component: withErrorInfo(() => {
           const { topicId } = useParams()
           return <TopicPage topicId={topicId!} />
-        },
+        }),
       },
       {
         path: '/forum/add-new-topic',
-        Component: () => <NewTopicPage />,
+        Component: withErrorInfo(NewTopicPage),
       },
       {
         path: '/500',

--- a/packages/client/src/service/auth.service.ts
+++ b/packages/client/src/service/auth.service.ts
@@ -24,8 +24,7 @@ class AuthService {
       else {
         throw new Error((result as ErrorResponse).reason)
       }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
+    } catch (error) {
       if (error instanceof Error) store.dispatch(setError(error.message))
     }
   }
@@ -53,8 +52,7 @@ class AuthService {
       } else {
         throw new Error((result as ErrorResponse).reason)
       }
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
+    } catch (error) {
       if (error instanceof Error) store.dispatch(setError(error.message))
     }
   }

--- a/packages/client/src/service/auth.service.ts
+++ b/packages/client/src/service/auth.service.ts
@@ -1,12 +1,11 @@
+import { setError } from 'reducers/error'
 import { setUserContext, pending, result } from 'reducers/user'
 import store from 'store'
 import { type SignUpDataType, type SignInDataType, type User, type ErrorResponse, type Nullable } from '../types/types'
 import { BASE_URL } from '../utils/constants'
 
-/* eslint-disable no-console*/
 class AuthService {
   baseURL: string = BASE_URL
-
   async signUp(data: SignUpDataType, afterSignUp: (login: string, password: string) => void): Promise<void> {
     try {
       const response: Response = await fetch(this.baseURL + '/auth/signup', {
@@ -25,8 +24,9 @@ class AuthService {
       else {
         throw new Error((result as ErrorResponse).reason)
       }
-    } catch (error) {
-      console.log(error)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      if (error instanceof Error) store.dispatch(setError(error.message))
     }
   }
 
@@ -53,8 +53,9 @@ class AuthService {
       } else {
         throw new Error((result as ErrorResponse).reason)
       }
-    } catch (error) {
-      console.log(error)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      if (error instanceof Error) store.dispatch(setError(error.message))
     }
   }
 
@@ -70,6 +71,7 @@ class AuthService {
         mode: 'cors',
       })
       if (response.status !== 200) {
+        store.dispatch(setError('Ошибка!'))
         throw new Error('Ошибка!')
       } else {
         callback()

--- a/yarn.lock
+++ b/yarn.lock
@@ -8105,6 +8105,13 @@ react-dom@18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-error-boundary@^4.0.12:
+  version "4.0.12"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.12.tgz#59f8f1dbc53bbbb34fc384c8db7cf4082cb63e2c"
+  integrity sha512-kJdxdEYlb7CPC1A0SeUY38cHpjuu6UkvzKiAmqmOFL21VRfMhOcWxTCBgLVCO0VEMh9JhFNcVaXlV4/BTpiwOA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-fast-compare@^3.0.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.2.tgz#929a97a532304ce9fee4bcae44234f1ce2c21d49"


### PR DESCRIPTION
- исп библотека react-error-boundary - отлавливает run-time ошибки, которые встречаются в компонентах
- создан HOC hoc/withErrorInfo  - для обертки компонента, на месте которого может возникнуть ошибка
- вывод ошибки - при помощи компонента errorB
- в итоге при возникновении ошибки выводится сообщение на весь экран - 
<img width="1430" alt="Снимок экрана 2024-01-09 в 11 53 31" src="https://github.com/AVor0n/tank-chess/assets/136781018/3378e4c1-e48c-4f08-926f-0a576831910f">
- I crushed меняется на более осмысленный текст ошибки
- это сообщение можно выводить и на меньшей области - на месте любого участка компонента. Достаточно обернуть его в ErrorBoundary



- Проблема в том, что не обрабатываются ошибки в обработчиках и асинхр коде, а хотелось бы.
- Поэтому созд еще один компонент Error и слайс для него в Redux - error
- Теперь в месте отлова ошибки в коде надо сделать store.dispatch(setError('текст ошибки')) и тогда всплывет сообщение об ошибке, которое по таймеру через несколько секунд погаснет.
<img width="1331" alt="Снимок экрана 2024-01-09 в 12 09 26" src="https://github.com/AVor0n/tank-chess/assets/136781018/74b75e05-d61c-463d-b19f-a3f5ef336884">
